### PR TITLE
clean up properly

### DIFF
--- a/src/Message.vue
+++ b/src/Message.vue
@@ -101,7 +101,9 @@ export default {
   },
 
   destroyed () {
-    this.$el.remove()
+    if (this.$el.parentNode) {
+      this.$el.parentNode.removeChild(this.$el)
+    }
   },
 
   computed: {


### PR DESCRIPTION
Using this.$el.remove() with IE11 causes an error, since the method is not available. instead, use parent's method for this.